### PR TITLE
add http to neuvoo.com link

### DIFF
--- a/_posts/2016-05-01-seeking-dev-work.md
+++ b/_posts/2016-05-01-seeking-dev-work.md
@@ -27,7 +27,7 @@ Want to freelance? [Be prepared to handle clients](http://blog.hightail.com/how-
 * [The Muse jobs board](https://www.themuse.com/jobs)
 * [DevPost](http://devpost.com/): a jobs board collecting job posts seeking developers.
 * [Apprentice.io](http://www.apprentice.io/): ThoughtBot's program for new web developers, it tends to be popular.
-* [Neuvoo](neuvoo.com), a job search engine that indexes job offers directly from companies' websites.
+* [Neuvoo](http://neuvoo.com), a job search engine that indexes job offers directly from companies' websites.
 
 #### Places that search for job matches on your behalf
 * [Hired](https://hired.com/): create your profile, and they match you with companies who bid on you.


### PR DESCRIPTION
was getting a 404 error without http:// in the neuvoo.com url
was being interpreted as `http://stackforyourself.com/everything-else/2016/05/01/seeking-dev-work/neuvoo.com`